### PR TITLE
Eliminate lita-ping responding to messages meant for lita-netping

### DIFF
--- a/lib/lita/handlers/ping.rb
+++ b/lib/lita/handlers/ping.rb
@@ -3,7 +3,7 @@ require "lita"
 module Lita
   module Handlers
     class Ping < Handler
-      route(/(p|P)ing/, :reply, command: true, help: {
+      route(/(p|P)ing\W*$/, :reply, command: true, help: {
         "ping" => "Gives you back a pong if the bot is online and listening."
       })
 


### PR DESCRIPTION
If you use both lita-netping and lita-ping, the latter will answer when you mean to use the former.  A simple tweak to the regex fixes this.
