### PR TITLE
Resolve depreciation

### DIFF
--- a/lib/lita/handlers/ping.rb
+++ b/lib/lita/handlers/ping.rb
@@ -7,7 +7,7 @@ module Lita
         "ping" => "Gives you back a pong if the bot is online and listening."
       })
 
-      def self.default_config(handler_config)
+      def self.config(handler_config)
       end
       
       def reply(response)


### PR DESCRIPTION
Getting this when I use lita-ping

```
WARN: Lita::Handler.default_config is deprecated and will be removed in Lita 5.0. 
Use Lita::Handler.config instead. The method was found defined in the ping handler.
```

This PR fixes that
